### PR TITLE
pass all transfer state to backend on final notification for incoming transfers

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusintegration/mojaloop-connector",
-  "version": "13.1.0",
+  "version": "13.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusintegration/mojaloop-connector",
-  "version": "13.1.0",
+  "version": "13.2.0",
   "description": "An adapter for connecting to Mojaloop API enabled switches.",
   "main": "index.js",
   "scripts": {

--- a/src/test/unit/lib/model/InboundTransfersModel.test.js
+++ b/src/test/unit/lib/model/InboundTransfersModel.test.js
@@ -629,7 +629,12 @@ describe('inboundModel', () => {
 
         test('sends notification to fsp backend', async () => {
             BackendRequests.__putTransfersNotification = jest.fn().mockReturnValue(Promise.resolve({}));
-            const backendResponse = JSON.parse(JSON.stringify(notificationToPayee));
+            const notif = JSON.parse(JSON.stringify(notificationToPayee));
+
+            const expectedRequest = {
+                currentState: 'COMPLETED',
+                finalNotification: notif.data,
+            };
 
             const model = new Model({
                 ...config,
@@ -637,10 +642,10 @@ describe('inboundModel', () => {
                 logger,
             });
 
-            await model.sendNotificationToPayee(backendResponse.data, transferId);
+            await model.sendNotificationToPayee(notif.data, transferId);
             expect(BackendRequests.__putTransfersNotification).toHaveBeenCalledTimes(1);
             const call = BackendRequests.__putTransfersNotification.mock.calls[0];
-            expect(call[0]).toEqual(backendResponse.data);
+            expect(call[0]).toEqual(expectedRequest);
             expect(call[1]).toEqual(transferId);
         });
     });


### PR DESCRIPTION
When a patch (final notification) call comes in for a transfer, pass all cached state e.g. quote request/response to the backend as well as the patch result.

Previous to this change, the only thing passed to the backend when a "final notification" is received (inbound) was the PATCH notification body. This does not contain enough contextual information for the backend to process in a stateless way i.e. quote request/response.

The ML connector takes responsibility for caching state so it should pass this along so the backend can act without needing its own state cache and correlation mechanism.