### PR TITLE
remove validation regex on firstname, lastname, middlename

### DIFF
--- a/src/InboundServer/api.yaml
+++ b/src/InboundServer/api.yaml
@@ -3223,7 +3223,6 @@ components:
       type: string
       minLength: 1
       maxLength: 128
-      pattern: '^(?!\s*$)[\w .,''-]{1,128}$'
       description: First name of the Party (Name Type).
     FspId:
       title: FspId
@@ -3263,7 +3262,6 @@ components:
       type: string
       minLength: 1
       maxLength: 128
-      pattern: '^(?!\s*$)[\w .,''-]{1,128}$'
       description: Last name of the Party (Name Type).
     Latitude:
       title: Latitude
@@ -3294,12 +3292,10 @@ components:
       type: string
       minLength: 1
       maxLength: 128
-      pattern: '^(?!\s*$)[\w .,''-]{1,128}$'
       description: Middle name of the Party (Name Type).
     Name:
       title: Name
       type: string
-      pattern: '^(?!\s*$)[\w .,''-]{1,128}$'
       description: >-
         The API data type Name is a JSON String, restricted by a regular
         expression to avoid characters which are generally not used in a name.

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusintegration/mojaloop-connector",
-  "version": "13.7.0",
+  "version": "13.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusintegration/mojaloop-connector",
-  "version": "13.7.0",
+  "version": "13.7.1",
   "description": "An adapter for connecting to Mojaloop API enabled switches.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
remove validation regex on firstname, lastname, middlename of incoming moja parties elements to enable full unicode support. note that this should be replaced once ALS is updated to support full unicode name elements e.g. myanmar script.