### PR TITLE
fix outbound GET /parties request auth.

### DIFF
--- a/src/lib/model/PartiesModel.js
+++ b/src/lib/model/PartiesModel.js
@@ -209,7 +209,7 @@ function injectHandlersContext(config) {
                     jwsSign: config.jwsSign,
                     jwsSignPutParties: config.jwsSignPutParties,
                     jwsSigningKey: config.jwsSigningKey,
-                    wso2Auth: config.wso2Auth
+                    wso2: config.wso2Auth
                 })
             }
         }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusintegration/mojaloop-connector",
-  "version": "13.7.2",
+  "version": "13.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8507,7 +8507,7 @@
       "dev": true
     },
     "oauth2-server": {
-      "version": "git://github.com/oauthjs/node-oauth2-server.git#015416563fcd5f0dd58e562aabd1b117d4bfa361",
+      "version": "git://github.com/oauthjs/node-oauth2-server.git#45b508afa2f7b6272df54d324b95bc3f7528cdbb",
       "from": "git://github.com/oauthjs/node-oauth2-server.git#dev",
       "requires": {
         "basic-auth": "^2.0.0",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusintegration/mojaloop-connector",
-  "version": "13.7.2",
+  "version": "13.7.3",
   "description": "An adapter for connecting to Mojaloop API enabled switches.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
fix bad merge back from upstream scheme adapter causing oauth headers to not be added to outbound party lookup requests.