### PR TITLE
fix: inbound and outbound transfers to use different cache keys to avoid clashing

### DIFF
--- a/src/lib/cache/package-lock.json
+++ b/src/lib/cache/package-lock.json
@@ -1,0 +1,42 @@
+{
+  "name": "@internal/cache",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
+    },
+    "redis": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "requires": {
+        "denque": "^1.5.0",
+        "redis-commands": "^1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
+    }
+  }
+}

--- a/src/lib/model/InboundTransfersModel.js
+++ b/src/lib/model/InboundTransfersModel.js
@@ -294,7 +294,7 @@ class InboundTransfersModel {
 
         try {
             // retrieve our quote data
-            this.data = await this._cache.get(`transferModel_${prepareRequest.transferId}`);
+            this.data = await this._cache.get(`transferModel_in_${prepareRequest.transferId}`);
             const quote = this.data.quote;
 
             if(!this.data || !quote) {
@@ -734,7 +734,7 @@ class InboundTransfersModel {
     async sendNotificationToPayee(body, transferId) {
         try {
             // load any cached state for this transfer e.g. quote request/response etc...
-            this.data = await this._cache.get(`transferModel_${transferId}`);
+            this.data = await this._cache.get(`transferModel_in_${transferId}`);
 
             // if we didnt have anything cached, start from scratch
             if(!this.data) {
@@ -794,7 +794,7 @@ class InboundTransfersModel {
      */
     async _save() {
         try {
-            const res = await this._cache.set(`transferModel_${this.data.transferId}`, this.data);
+            const res = await this._cache.set(`transferModel_in_${this.data.transferId}`, this.data);
             this._logger.push({ res }).log('Persisted transfer model in cache');
         }
         catch(err) {

--- a/src/lib/model/OutboundTransfersModel.js
+++ b/src/lib/model/OutboundTransfersModel.js
@@ -942,7 +942,7 @@ class OutboundTransfersModel {
     async _save() {
         try {
             this.data.currentState = this.stateMachine.state;
-            const res = await this._cache.set(`transferModel_${this.data.transferId}`, this.data);
+            const res = await this._cache.set(`transferModel_out_${this.data.transferId}`, this.data);
             this._logger.push({ res }).log('Persisted transfer model in cache');
         }
         catch(err) {
@@ -959,7 +959,7 @@ class OutboundTransfersModel {
      */
     async load(transferId) {
         try {
-            const data = await this._cache.get(`transferModel_${transferId}`);
+            const data = await this._cache.get(`transferModel_out_${transferId}`);
             if(!data) {
                 throw new Error(`No cached data found for transferId: ${transferId}`);
             }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusintegration/mojaloop-connector",
-  "version": "13.7.6",
+  "version": "13.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusintegration/mojaloop-connector",
-  "version": "13.8.0",
+  "version": "14.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusintegration/mojaloop-connector",
-  "version": "13.7.6",
+  "version": "13.8.0",
   "description": "An adapter for connecting to Mojaloop API enabled switches.",
   "main": "index.js",
   "scripts": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusintegration/mojaloop-connector",
-  "version": "13.8.0",
+  "version": "14.0.0",
   "description": "An adapter for connecting to Mojaloop API enabled switches.",
   "main": "index.js",
   "scripts": {

--- a/src/test/unit/lib/model/InboundTransfersModel.test.js
+++ b/src/test/unit/lib/model/InboundTransfersModel.test.js
@@ -286,7 +286,7 @@ describe('inboundModel', () => {
                 logger,
                 rejectTransfersOnExpiredQuotes: true,
             });
-            cache.set(`transferModel_${TRANSFER_ID}`, {
+            cache.set(`transferModel_in_${TRANSFER_ID}`, {
                 quote: {
                     mojaloopResponse: {
                         expiration: new Date(new Date().getTime() - 1000).toISOString(),


### PR DESCRIPTION
ensure inbound and outbound transfers use different cache keys so one instance can be payer and payee without state clashing