### PR TITLE
allow custom error description to be sent with standard error codes

### DIFF
--- a/src/lib/model/InboundTransfersModel.js
+++ b/src/lib/model/InboundTransfersModel.js
@@ -774,9 +774,14 @@ class InboundTransfersModel {
             if(e.res && e.res.data) {
                 // look for a standard mojaloop error that matches the statusCode
                 let mojaloopErrorCode = Errors.MojaloopApiErrorCodeFromCode(`${e.res.data.statusCode}`);
+                let errorDescription = e.res.data.message;
                 if(mojaloopErrorCode) {
                     // use the standard mojaloop error object
                     mojaloopError = (new Errors.MojaloopFSPIOPError(err, null, null, mojaloopErrorCode)).toApiErrorObject();
+                    if(errorDescription) {
+                        // if the error has a description, use that instead of the default mojaloop description
+                        mojaloopError.errorInformation.errorDescription = errorDescription;
+                    }
                 }
                 else {
                     // this is a custom error, so construct a mojaloop spec body

--- a/src/lib/model/InboundTransfersModel.js
+++ b/src/lib/model/InboundTransfersModel.js
@@ -780,6 +780,8 @@ class InboundTransfersModel {
                     mojaloopError = (new Errors.MojaloopFSPIOPError(err, null, null, mojaloopErrorCode)).toApiErrorObject();
                     if(errorDescription) {
                         // if the error has a description, use that instead of the default mojaloop description
+                        // note that the mojaloop API spec allows any string up to 128 utf8 characters to be sent
+                        // in the errorDescription field.
                         mojaloopError.errorInformation.errorDescription = errorDescription;
                     }
                 }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusintegration/mojaloop-connector",
-  "version": "14.1.0",
+  "version": "14.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusintegration/mojaloop-connector",
-  "version": "14.1.0",
+  "version": "14.1.1",
   "description": "An adapter for connecting to Mojaloop API enabled switches.",
   "main": "index.js",
   "scripts": {

--- a/src/test/unit/lib/model/InboundTransfersModel.test.js
+++ b/src/test/unit/lib/model/InboundTransfersModel.test.js
@@ -686,7 +686,6 @@ describe('inboundModel', () => {
                 res: {
                     data: {
                         statusCode: '3200',
-                        message: 'some custom message',
                     },
                 }
             });
@@ -728,5 +727,34 @@ describe('inboundModel', () => {
             expect(err.errorInformation.errorCode).toEqual('3299');
             expect(err.errorInformation.errorDescription).toEqual(customMessage);
         });
+
+        test('creates custom error message when backend returns standard error code and message', async () => {
+            const model = new Model({
+                ...config,
+                cache,
+                logger,
+            });
+
+            const customMessage = 'some custom message';
+
+            const testErr = new HTTPResponseError({
+                msg: 'Request returned non-success status code 500',
+                res: {
+                    data: {
+                        statusCode: '3200',
+                        message: customMessage,
+                    },
+                }
+            });
+
+            const err = await model._handleError(testErr);
+
+            expect(err).toBeDefined();
+            expect(err.errorInformation).toBeDefined();
+            expect(err.errorInformation.errorCode).toEqual('3200');
+            // error message should be custom
+            expect(err.errorInformation.errorDescription).toEqual(customMessage);
+        });
+
     });
 });


### PR DESCRIPTION
allow custom error description to be sent from core connector through switch even when using standard mojaloop error code