### PR TITLE
fix: inbound api post transfer not mapping quoteRequestExtensions when sending request to backend

### DIFF
--- a/src/lib/model/lib/shared/index.js
+++ b/src/lib/model/lib/shared/index.js
@@ -260,8 +260,8 @@ const mojaloopPrepareToInternalTransfer = (external, quote, ilp) => {
             },
             note: quote.request.note
         };
-        if (quote.internalRequest && quote.internalRequest.extensionList && quote.internalRequest.extensionList.extension) {
-            internal.quoteRequestExtensions = { ...quote.internalRequest.extensionList.extension };
+        if (quote.internalRequest && quote.internalRequest.extensionList) {
+            internal.quoteRequestExtensions = { ...quote.internalRequest.extensionList };
         }
     } else {
         internal = {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusintegration/mojaloop-connector",
-  "version": "14.1.1",
+  "version": "14.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusintegration/mojaloop-connector",
-  "version": "14.1.1",
+  "version": "14.1.2",
   "description": "An adapter for connecting to Mojaloop API enabled switches.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- updated mojaloopPrepareToInternalTransfer mapping align to data structure stored in cache
- bump to patch version